### PR TITLE
Install virtual audio devices for simulator

### DIFF
--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -71,8 +71,10 @@ build {
     inline = [
       "source ~/.zprofile",
       "brew install libimobiledevice ideviceinstaller ios-deploy fastlane",
+      "brew install blackhole-2ch",
       "sudo gem update",
-      "sudo gem install cocoapods"
+      "sudo gem install cocoapods",
+      "sudo gem uninstall --ignore-dependencies ffi && sudo gem install ffi -- --enable-libffi-alloc"
     ]
   }
 }


### PR DESCRIPTION
It appeared that iOS simulator is not OK when there is no audio outputs. Especially for video and audio players.

Unfortunetly, Apple's Virtualization.Framework only support virtual audio devices for Linux https://developer.apple.com/documentation/virtualization/audio