### PR TITLE
Add extra space to base image

### DIFF
--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -17,7 +17,7 @@ source "tart-cli" "tart" {
   vm_name      = "${var.macos_version}-base"
   cpu_count    = 4
   memory_gb    = 8
-  disk_size_gb = 30
+  disk_size_gb = 40
   ssh_password = "admin"
   ssh_username = "admin"
   ssh_timeout  = "120s"


### PR DESCRIPTION
Right now the base image has 10Gb free which is very conservative if you want to compile much of thing or install Node.js modules. The disk is compressed when pushed so this change shouldn't affect the size of pull that much.

Fixes https://github.com/cirruslabs/cirrus-ci-docs/issues/1065