### PR TITLE
Passwordless sudo via sudoers.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ tart run ventura-vanilla
     1. Run `sudo visudo /private/etc/sudoers.d/admin-passwordless` in Terminal.
     2. Add `admin ALL = (ALL) NOPASSWD: ALL` to allow `sudo` without a password.
     3. `:wq` to write the file and quit.
-    4. `sudo visudo -c` to verify your new file parsed OK.
-    5. `sudo` some command to verify no password is needed.
+    4. `sudo` some command to verify no password is needed.
 
 Shutdown macOS.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ tart run ventura-vanilla
 3. Allow SSH. General -> Sharing -> Remote Login & Screen Sharing
 4. Display -> Advanced -> Prevent from sleeping
 5. Open Safari. Preferences -> Advanced -> Show Developer menu. Develop -> Allow Remote Automation.
+6. Disable SIP. Run `tart run --recovery ventura-vanilla` -> Options -> Utilities menu -> Terminal -> `csrutil disable`.
 7. Enable passwordless `sudo`:
     1. Run `sudo visudo /private/etc/sudoers.d/admin-passwordless` in Terminal.
     2. Add `admin ALL = (ALL) NOPASSWD: ALL` to allow `sudo` without a password.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ tart run ventura-vanilla
 3. Allow SSH. General -> Sharing -> Remote Login & Screen Sharing
 4. Display -> Advanced -> Prevent from sleeping
 5. Open Safari. Preferences -> Advanced -> Show Developer menu. Develop -> Allow Remote Automation.
-6. Disable SIP. Run `tart run --recovery ventura-vanilla` -> Options -> Utilities menu -> Terminal -> `csrutil disable`.
+6. (Optional, depends on your needs) Disable SIP. Run `tart run --recovery ventura-vanilla` -> Options -> Utilities menu -> Terminal -> `csrutil disable`.
 7. Enable passwordless `sudo`:
     1. Run `sudo visudo /private/etc/sudoers.d/admin-passwordless` in Terminal.
     2. Add `admin ALL = (ALL) NOPASSWD: ALL` to allow `sudo` without a password.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ tart run ventura-vanilla
 3. Allow SSH. General -> Sharing -> Remote Login & Screen Sharing
 4. Display -> Advanced -> Prevent from sleeping
 5. Open Safari. Preferences -> Advanced -> Show Developer menu. Develop -> Allow Remote Automation.
-6. Sisable SIP. Run `tart run --recovery ventura-vanilla` -> Options -> Utilities menu -> Terminal -> `csrutil disable`.
-7. Run `sudo visudo` in Terminal, find `%admin ALL=(ALL) ALL` add `admin ALL=(ALL) NOPASSWD: ALL` to allow sudo without a password.
+7. Enable passwordless `sudo`:
+    1. Run `sudo visudo /private/etc/sudoers.d/admin-passwordless` in Terminal.
+    2. Add `admin ALL = (ALL) NOPASSWD: ALL` to allow `sudo` without a password.
+    3. `:wq` to write the file and quit.
+    4. `sudo visudo -c` to verify your new file parsed OK.
+    5. `sudo` some command to verify no password is needed.
 
 Shutdown macOS.
 


### PR DESCRIPTION
The `sudoers.d` directory is in-play via the line `#includedir /private/etc/sudoers.d` inside `/private/etc/sudoers`.

By using it, I think it's unnecessary to disable System Integrity Protection. SIP is the thing - I think - that objects to edits inside `/private/etc/sudoers`, and will blow those away on OS updates and so forth.

I totally get:
- you might have other reasons for disabling SIP (I didn't find reference...?)
- you might not care about OS updates since (I bet) the intended use-case is for short-lived containers

... but I figure doing this is one less step away from Apple's defaults, and so one less thing to check as Apple issues updates.

I verified that this worked for me via running it, then shutting down the VM, restarting, and checking I could still passwordless-sudo.

I _didn't_ verify that this survived an OS-update because I was using the 12.6 current-latest monterey.

(If you're happy to accept this, there's a similar step in https://github.com/cirruslabs/tart#creating-a-macos-vm-image-from-scratch that should probably change to match).