### PR TITLE
Homebrew won't prompt

### DIFF
--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -48,7 +48,7 @@ build {
   }
   provisioner "shell" {
     inline = [
-      "yes '' | /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+      "/bin/bash -c \"$(NONINTERACTIVE=1 curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
       "echo \"export LANG=en_US.UTF-8\" >> ~/.zprofile",
       "echo 'eval \"$(/opt/homebrew/bin/brew shellenv)\"' >> ~/.zprofile",
       "echo \"export HOMEBREW_NO_AUTO_UPDATE=1\" >> ~/.zprofile",

--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -48,7 +48,7 @@ build {
   }
   provisioner "shell" {
     inline = [
-      "/bin/bash -c \"$(NONINTERACTIVE=1 curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+      "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
       "echo \"export LANG=en_US.UTF-8\" >> ~/.zprofile",
       "echo 'eval \"$(/opt/homebrew/bin/brew shellenv)\"' >> ~/.zprofile",
       "echo \"export HOMEBREW_NO_AUTO_UPDATE=1\" >> ~/.zprofile",


### PR DESCRIPTION
Homebrew detects it isn't running in a TTY, and will not prompt. This can be seen from the output:
`    tart-cli.tart: Warning: Running in non-interactive mode because `stdin is not a TTY.`