### PR TITLE
Enable Screen Sharing via boot_command in templates

### DIFF
--- a/templates/vanilla-ventura.pkr.hcl
+++ b/templates/vanilla-ventura.pkr.hcl
@@ -63,8 +63,10 @@ source "tart-cli" "tart" {
     "<wait10s><leftAltOn><spacebar><leftAltOff>System Settings<enter>",
     # Navigate to "Sharing"
     "<wait10s><leftAltOn>f<leftAltOff>sharing<enter>",
+    # Navigate to "Screen Sharing" and enable it
+    "<wait10s><tab><down><spacebar>",
     # Navigate to "Remote Login" and enable it
-    "<wait10s><tab><tab><tab><tab><tab><tab><tab><spacebar>",
+    "<wait10s><tab><tab><tab><tab><tab><tab><spacebar>",
     # Open "Remote Login" details
     "<wait10s><tab><spacebar>",
     # Enable "Full Disk Access"


### PR DESCRIPTION
I felt like adding Screen Sharing (along with SSH) might be useful to have as a default in this template. If you agree (?), I can also go and make the equivalent change for Monterey in this same PR.

The reason to enable Screen Sharing this way is because in Monterey 12.1, Apple made a change where setting Screen Sharing via automated means (like `launchctl load`-ing the screensharing service, or the `kickstart` ARD setup command) would not enable all the necessary TCC rights to have functional screen sharing. Either SIP would need to be disabled, or the machine enrolled in MDM, to push out the config. So, doing it manually via the checkbox in sysprefs seemed like the best way here.