### PR TITLE
Ensure that English is chosen

### DIFF
--- a/templates/vanilla-ventura.pkr.hcl
+++ b/templates/vanilla-ventura.pkr.hcl
@@ -22,7 +22,7 @@ source "tart-cli" "tart" {
     # hello, hola, bonjour, etc.
     "<wait60s><spacebar>",
     # Language
-    "<wait30s><enter>",
+    "<wait30s>english<enter>",
     # Select Your Country and Region
     "<wait30s>united states<leftShiftOn><tab><leftShiftOff><spacebar>",
     # Written and Spoken Languages


### PR DESCRIPTION
The Ventura setup in Japan shows Japanese in the first choice. Typing english in the language selection screen ensures that the setup chooses English all over the world.