### PR TITLE
Rotate Apple Worldwide Developer Relations Intermediate Certificate

### DIFF
--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -14,7 +14,7 @@ variable "macos_version" {
 
 variable "xcode_version" {
   type =  string
-  default = "14.1-RC"
+  default = "14.1"
 }
 
 source "tart-cli" "tart" {
@@ -97,6 +97,20 @@ build {
       "sudo gem update",
       "sudo gem install cocoapods",
       "sudo gem uninstall --ignore-dependencies ffi && sudo gem install ffi -- --enable-libffi-alloc"
+    ]
+  }
+  # inspired by https://github.com/actions/runner-images/blob/fb3b6fd69957772c1596848e2daaec69eabca1bb/images/macos/provision/configuration/configure-machine.sh#L33-L61
+  provisioner "shell" {
+    inline = [
+      "source ~/.zprofile",
+      "sudo security delete-certificate -Z FF6797793A3CD798DC5B2ABEF56F73EDC9F83A64 /Library/Keychains/System.keychain",
+      "curl -o add-certificate.swift https://raw.githubusercontent.com/actions/runner-images/fb3b6fd69957772c1596848e2daaec69eabca1bb/images/macos/provision/configuration/add-certificate.swift",
+      "swiftc add-certificate.swift",
+      "curl -o AppleWWDRCAG3.cer https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer",
+      "curl -o DeveloperIDG2CA.cer https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer",
+      "sudo ./add-certificate AppleWWDRCAG3.cer",
+      "sudo ./add-certificate DeveloperIDG2CA.cer",
+      "rm add-certificate* *.cer"
     ]
   }
   provisioner "shell" {


### PR DESCRIPTION
Seems it makes notarization failing for some users that are able to do so on GHA.