### PR TITLE
Disabled screensaver for admin user.

### DIFF
--- a/templates/vanilla-monterey.pkr.hcl
+++ b/templates/vanilla-monterey.pkr.hcl
@@ -90,6 +90,8 @@ build {
       "sudo defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser admin",
       // Disable screensaver at login screen
       "sudo defaults write /Library/Preferences/com.apple.screensaver loginWindowIdleTime 0",
+      // Disable screensaver for admin user
+      "defaults -currentHost write com.apple.screensaver idleTime 0",
       // Prevent the VM from sleeping
       "sudo systemsetup -setdisplaysleep Off",
       "sudo systemsetup -setsleep Off",

--- a/templates/vanilla-sonoma.pkr.hcl
+++ b/templates/vanilla-sonoma.pkr.hcl
@@ -99,6 +99,8 @@ build {
       "sudo defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser admin",
       // Disable screensaver at login screen
       "sudo defaults write /Library/Preferences/com.apple.screensaver loginWindowIdleTime 0",
+      // Disable screensaver for admin user
+      "defaults -currentHost write com.apple.screensaver idleTime 0",
       // Prevent the VM from sleeping
       "sudo systemsetup -setdisplaysleep Off",
       "sudo systemsetup -setsleep Off",

--- a/templates/vanilla-ventura.pkr.hcl
+++ b/templates/vanilla-ventura.pkr.hcl
@@ -96,6 +96,8 @@ build {
       "sudo defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser admin",
       // Disable screensaver at login screen
       "sudo defaults write /Library/Preferences/com.apple.screensaver loginWindowIdleTime 0",
+      // Disable screensaver for admin user
+      "defaults -currentHost write com.apple.screensaver idleTime 0",
       // Prevent the VM from sleeping
       "sudo systemsetup -setdisplaysleep Off",
       "sudo systemsetup -setsleep Off",


### PR DESCRIPTION
This addresses the issue when screensaver kicks in for admin user after 20 min (the default).

<img width="477" alt="Screenshot 2023-06-22 at 02 18 57" src="https://github.com/cirruslabs/macos-image-templates/assets/803905/7c8376b6-c7cf-45db-9733-379e8ee4755a">
