### PR TITLE
Pin version of `activesupport`

### DIFF
--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -117,9 +117,9 @@ build {
       "source ~/.zprofile",
       "brew install libimobiledevice ideviceinstaller ios-deploy fastlane carthage",
       "sudo gem update",
+      "sudo gem install activesupport -v 7.0.8",
       "sudo gem install cocoapods",
-      "sudo gem uninstall --ignore-dependencies ffi && sudo gem install ffi -- --enable-libffi-alloc",
-      "sudo gem uninstall activesupport && sudo gem install activesupport -v 7.0.8"
+      "sudo gem uninstall --ignore-dependencies ffi && sudo gem install ffi -- --enable-libffi-alloc"
     ]
   }
 

--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -118,7 +118,8 @@ build {
       "brew install libimobiledevice ideviceinstaller ios-deploy fastlane carthage",
       "sudo gem update",
       "sudo gem install cocoapods",
-      "sudo gem uninstall --ignore-dependencies ffi && sudo gem install ffi -- --enable-libffi-alloc"
+      "sudo gem uninstall --ignore-dependencies ffi && sudo gem install ffi -- --enable-libffi-alloc",
+      "sudo gem uninstall activesupport && sudo gem install activesupport -v 7.0.8"
     ]
   }
 


### PR DESCRIPTION
Fixes #100 while https://github.com/CocoaPods/CocoaPods/issues/12081 is not released.