### PR TITLE
disable-sip.pkr.hcl: a better way to open Terminal

### DIFF
--- a/templates/disable-sip.pkr.hcl
+++ b/templates/disable-sip.pkr.hcl
@@ -22,11 +22,8 @@ source "tart-cli" "tart" {
     # Skip over "Macintosh" and select "Options"
     # to boot into macOS Recovery
     "<wait60s><right><right><enter>",
-    # Select default language
-    "<wait10s><enter>",
     # Open Terminal
-    "<wait10s><leftCtrlOn><f2><leftCtrlOff>",
-    "<right><right><right><right><down><down><down><enter>",
+    "<wait10s><leftAltOn>T<leftAltOff>",
     # Disable SIP
     "<wait10s>csrutil disable<enter>",
     "<wait10s>y<enter>",


### PR DESCRIPTION
Without it, we open the "Share Disk..." menu option instead.

Also there's no more default language choice on Sonoma.