### PR TITLE
Tag vanilla image as 14.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,7 @@ task:
   disable_sip_script:
     - packer build -var vm_name=sonoma-vanilla templates/disable-sip.pkr.hcl
   push_script:
-    - tart push sonoma-vanilla ghcr.io/cirruslabs/macos-sonoma-vanilla:latest
+    - tart push sonoma-vanilla ghcr.io/cirruslabs/macos-sonoma-vanilla:latest ghcr.io/cirruslabs/macos-sonoma-vanilla:14.1
   always:
     cleanup_script:
       - tart delete sonoma-vanilla || true


### PR DESCRIPTION
Since we currently use UniversalMac_14.1_23B74_Restore.ipsw to build it.