### PR TITLE
Just enable remote automation for Safari

### DIFF
--- a/templates/vanilla-monterey.pkr.hcl
+++ b/templates/vanilla-monterey.pkr.hcl
@@ -102,10 +102,8 @@ build {
       "disown",
       "sleep 30",
       "kill -9 $SAFARI_PID",
-      // Enable Safari's remote automation and "Develop" menu
+      // Enable Safari's remote automation
       "sudo safaridriver --enable",
-      "defaults write com.apple.Safari.SandboxBroker ShowDevelopMenu -bool true",
-      "defaults write com.apple.Safari IncludeDevelopMenu -bool true",
       // Disable screen lock
       //
       // Note that this only works if the user is logged-in,

--- a/templates/vanilla-sonoma.pkr.hcl
+++ b/templates/vanilla-sonoma.pkr.hcl
@@ -112,10 +112,8 @@ build {
       "disown",
       "sleep 30",
       "kill -9 $SAFARI_PID",
-      // Enable Safari's remote automation and "Develop" menu
+      // Enable Safari's remote automation
       "sudo safaridriver --enable",
-      "defaults write com.apple.Safari.SandboxBroker ShowDevelopMenu -bool true",
-      "defaults write com.apple.Safari IncludeDevelopMenu -bool true",
       // Disable screen lock
       //
       // Note that this only works if the user is logged-in,

--- a/templates/vanilla-ventura.pkr.hcl
+++ b/templates/vanilla-ventura.pkr.hcl
@@ -108,10 +108,8 @@ build {
       "disown",
       "sleep 30",
       "kill -9 $SAFARI_PID",
-      // Enable Safari's remote automation and "Develop" menu
+      // Enable Safari's remote automation
       "sudo safaridriver --enable",
-      "defaults write com.apple.Safari.SandboxBroker ShowDevelopMenu -bool true",
-      "defaults write com.apple.Safari IncludeDevelopMenu -bool true",
       // Disable screen lock
       //
       // Note that this only works if the user is logged-in,


### PR DESCRIPTION
Enabling `Develop` menu started failing in 14.3 with:

```console
Could not write domain /Users/admin/Library/Containers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari; exiting
```

We actually only interested in enabling remote automation for CI which is done by `safaridriver`. Having `Develop` menu item is not necessary.