### PR TITLE
No need to populate `/usr/local/bin/`

### DIFF
--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -76,7 +76,6 @@ build {
 
   provisioner "shell" {
     inline = [
-      "echo 'export PATH=/usr/local/bin/:$PATH' >> ~/.zprofile",
       "source ~/.zprofile",
       "brew install xcodesorg/made/xcodes",
       "xcodes version",
@@ -123,13 +122,12 @@ build {
     inline = [
       "source ~/.zprofile",
       "sudo security delete-certificate -Z FF6797793A3CD798DC5B2ABEF56F73EDC9F83A64 /Library/Keychains/System.keychain",
-      "curl -o add-certificate.swift https://raw.githubusercontent.com/actions/runner-images/fb3b6fd69957772c1596848e2daaec69eabca1bb/images/macos/provision/configuration/add-certificate.swift",
-      "swiftc add-certificate.swift",
-      "sudo mv ./add-certificate /usr/local/bin/add-certificate",
       "curl -o AppleWWDRCAG3.cer https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer",
       "curl -o DeveloperIDG2CA.cer https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer",
-      "sudo add-certificate AppleWWDRCAG3.cer",
-      "sudo add-certificate DeveloperIDG2CA.cer",
+      "curl -o add-certificate.swift https://raw.githubusercontent.com/actions/runner-images/fb3b6fd69957772c1596848e2daaec69eabca1bb/images/macos/provision/configuration/add-certificate.swift",
+      "swiftc -suppress-warnings add-certificate.swift",
+      "sudo ./add-certificate AppleWWDRCAG3.cer",
+      "sudo ./add-certificate DeveloperIDG2CA.cer",
       "rm add-certificate* *.cer"
     ]
   }


### PR DESCRIPTION
Plus we only need `add-certificate` during the build and don't need it in the image