### PR TITLE
Install Node.js LTS

### DIFF
--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -85,7 +85,7 @@ build {
   provisioner "shell" {
     inline = [
       "source ~/.zprofile",
-      "brew install node",
+      "brew install node@20",
       "node --version",
       "npm install --global yarn",
       "yarn --version",


### PR DESCRIPTION
Right now `brew install node` installs the current version 21 of Node.js. Let's make sure we install an LTS version. It's updated not that often so can update it manually.