### PR TITLE
Fixed Simulator Opening

### DIFF
--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -103,6 +103,18 @@ build {
     ]
   }
 
+  // warm up Xcodes by opening all of them, waiting a minute and trying to open Simulator app
+  // to make things clean we'll set ApplePersistence so on restart macOS won't try to reopen all the apps
+  provisioner "shell" {
+    inline = [
+      "source ~/.zprofile",
+      "defaults write -g ApplePersistence -bool no",
+      "open /Applications/Xcode*.app",
+      "sleep 60",
+      "open -a Simulator"
+    ]
+  }
+
   provisioner "shell" {
     inline = [
       "source ~/.zprofile",
@@ -164,7 +176,7 @@ build {
       "source ~/.zprofile",
       "df -h",
       "export FREE_MB=$(df -m | awk '{print $4}' | head -n 2 | tail -n 1)",
-      "[[ $FREE_MB -gt 20000 ]] && echo OK || exit 1"
+      "[[ $FREE_MB -gt 15000 ]] && echo OK || exit 1"
     ]
   }
 }


### PR DESCRIPTION
For some reason `open -a Simulator` stopped working and only opening by a full path works.

I was able to fix it manually by launching Xcode manually and closing it. Seems it does something more than `xcodebuild -runFirstLaunch`.

In any case, this change intorcudces a warmup script for Xcodes which opens all of them, waits a bit and verifies `open -a Simulator` works.