### PR TITLE
Install Git Credentials Helper and xcpretty/xcbeauty

### DIFF
--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -59,8 +59,10 @@ build {
       "source ~/.zprofile",
       "brew --version",
       "brew update",
-      "brew install wget cmake gcc git-lfs jq gh gitlab-runner",
+      "brew install curl wget unzip zip ca-certificates cmake gcc git-lfs jq gh gitlab-runner",
+      "brew install --cask git-credential-manager",
       "git lfs install",
+      "sudo softwareupdate --install-rosetta --agree-to-license"
     ]
   }
 

--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -98,6 +98,8 @@ build {
     inline = [
       "source ~/.zprofile",
       "brew install node@20",
+      "echo 'export PATH=\"/opt/homebrew/opt/node@20/bin:$PATH\"' >> ~/.zprofile",
+      "source ~/.zprofile",
       "node --version",
       "npm install --global yarn",
       "yarn --version",

--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -52,8 +52,6 @@ build {
       "brew --version",
       "brew update",
       "brew upgrade",
-      "brew install curl wget unzip zip ca-certificates",
-      "sudo softwareupdate --install-rosetta --agree-to-license"
     ]
   }
 
@@ -121,8 +119,10 @@ build {
     inline = [
       "source ~/.zprofile",
       "brew install libimobiledevice ideviceinstaller ios-deploy fastlane carthage",
+      "brew install xcbeautify",
       "gem update",
       "gem install cocoapods",
+      "gem install xcpretty",
       "gem uninstall --ignore-dependencies ffi && gem install ffi -- --enable-libffi-alloc"
     ]
   }


### PR DESCRIPTION
Plus move rosetta installation and some other common packages into base variant.