### PR TITLE
Make sure `/Users/runner` exists in `xcode` variant

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,5 +21,5 @@ packer build -var macos_version=sonoma templates/base.pkr.hcl
 ## Building Xcode Image
 
 ```bash
-packer build -var macos_version=sonoma -var xcode_version=15.3 templates/xcode.pkr.hcl
+packer build -var macos_version=sonoma -var xcode_version="[15.3]" templates/xcode.pkr.hcl
 ```

--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -121,4 +121,12 @@ build {
   provisioner "shell" {
     script = "scripts/automationmodetool.expect"
   }
+
+  // some other health checks
+  provisioner "shell" {
+    inline = [
+      "source ~/.zprofile",
+      "test -d /Users/runner"
+    ]
+  }
 }

--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -60,6 +60,13 @@ build {
     script = "scripts/install-actions-runner.sh"
   }
 
+  // make sure our workaround from base is still valid
+  provisioner "shell" {
+    inline = [
+      "sudo ln -s /Users/admin /Users/runner || true"
+    ]
+  }
+
   provisioner "shell" {
     inline = [
       "source ~/.zprofile",
@@ -158,13 +165,21 @@ build {
     ]
   }
 
-  // check there is at least 20GB of free space and fail if not
+  // check there is at least 15GB of free space and fail if not
   provisioner "shell" {
     inline = [
       "source ~/.zprofile",
       "df -h",
       "export FREE_MB=$(df -m | awk '{print $4}' | head -n 2 | tail -n 1)",
       "[[ $FREE_MB -gt 15000 ]] && echo OK || exit 1"
+    ]
+  }
+
+  // some other health checks
+  provisioner "shell" {
+    inline = [
+      "source ~/.zprofile",
+      "test -d /Users/runner"
     ]
   }
 }


### PR DESCRIPTION
A follow-up to #145. It seems right now only base variant preserves the symlink. `xcode` and `runner` are missing it and my guess it's due to disk resizing.

This change adds a validation script, so we verify `/Users/runner` folder exists in every variant.