### PR TITLE
Use Keyboard navigation instead of Voice Over for System Settings navigation

### DIFF
--- a/templates/vanilla-sequoia.pkr.hcl
+++ b/templates/vanilla-sequoia.pkr.hcl
@@ -62,7 +62,7 @@ source "tart-cli" "tart" {
     # Choose Your Look
     "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar>",
     # Welcome to Mac
-    "<wait10s><tab><spacebar>",
+    "<wait10s><spacebar>",
     # Enable Keyboard navigation
     # This is so that we can navigate the System Settings app using the keyboard
     "<wait10s><leftAltOn><spacebar><leftAltOff>Terminal<enter>",

--- a/templates/vanilla-sequoia.pkr.hcl
+++ b/templates/vanilla-sequoia.pkr.hcl
@@ -63,8 +63,11 @@ source "tart-cli" "tart" {
     "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar>",
     # Welcome to Mac
     "<wait10s><tab><spacebar>",
-    # Enable Voice Over
-    "<wait10s><leftAltOn><f5><leftAltOff><wait5s>v",
+    # Enable Keyboard navigation
+    # This is so that we can navigate the System Settings app using the keyboard
+    "<wait10s><leftAltOn><spacebar><leftAltOff>Terminal<enter>",
+    "<wait10s>defaults write NSGlobalDomain AppleKeyboardUIMode -int 3<enter>",
+    "<wait10s><leftAltOn>q<leftAltOff>",
     # Now that the installation is done, open "System Settings"
     "<wait10s><leftAltOn><spacebar><leftAltOff>System Settings<enter>",
     # Navigate to "Sharing"
@@ -75,6 +78,8 @@ source "tart-cli" "tart" {
     "<wait10s><tab><tab><tab><tab><tab><tab><tab><tab><tab><tab><tab><tab><spacebar>",
     # Disable Voice Over
     "<leftAltOn><f5><leftAltOff>",
+    # Quit System Settings
+    "<wait10s><leftAltOn>q<leftAltOff>",
   ]
 
   // A (hopefully) temporary workaround for Virtualization.Framework's

--- a/templates/vanilla-sequoia.pkr.hcl
+++ b/templates/vanilla-sequoia.pkr.hcl
@@ -104,9 +104,7 @@ build {
       // Disable screensaver for admin user
       "defaults -currentHost write com.apple.screensaver idleTime 0",
       // Prevent the VM from sleeping
-      "sudo systemsetup -setdisplaysleep Off 2>/dev/null",
       "sudo systemsetup -setsleep Off 2>/dev/null",
-      "sudo systemsetup -setcomputersleep Off 2>/dev/null",
       // Launch Safari to populate the defaults
       "/Applications/Safari.app/Contents/MacOS/Safari &",
       "SAFARI_PID=$!",


### PR DESCRIPTION
## What's changed?

I was experimenting with the vanilla Sequoia template here, and noticed that it kept crashing the moment it tried to enable Voice Over.

As a workaround — and possibly a better option — the "Keyboard navigation" setting can be enabled with a `defaults` command, allowing the navigation of the UI with the keyboard.

So this PR changes from using Voice Over to enabling Keyboard navigation instead. It also includes a couple other unrelated changes which I'll explain inline.