### PR TITLE
macOS Sequoia 15.1 beta 3

### DIFF
--- a/templates/vanilla-sequoia.pkr.hcl
+++ b/templates/vanilla-sequoia.pkr.hcl
@@ -76,8 +76,6 @@ source "tart-cli" "tart" {
     "<wait10s><tab><tab><tab><tab><tab><spacebar>",
     # Navigate to "Remote Login" and enable it
     "<wait10s><tab><tab><tab><tab><tab><tab><tab><tab><tab><tab><tab><tab><spacebar>",
-    # Disable Voice Over
-    "<leftAltOn><f5><leftAltOff>",
     # Quit System Settings
     "<wait10s><leftAltOn>q<leftAltOff>",
   ]

--- a/templates/vanilla-sequoia.pkr.hcl
+++ b/templates/vanilla-sequoia.pkr.hcl
@@ -8,7 +8,7 @@ packer {
 }
 
 source "tart-cli" "tart" {
-  from_ipsw    = "https://updates.cdn-apple.com/2024SummerSeed/fullrestores/062-71949/A67919DD-2AAC-4324-99BF-70765065DD70/UniversalMac_15.0_24A5331b_Restore.ipsw"
+  from_ipsw    = "https://updates.cdn-apple.com/2024SummerSeed/fullrestores/062-74506/D50AC8F9-4795-4711-9C1A-907B6EB829A2/UniversalMac_15.1_24B5035e_Restore.ipsw"
   vm_name      = "sequoia-vanilla"
   cpu_count    = 4
   memory_gb    = 8


### PR DESCRIPTION
This one can now be successfully installed on Sonoma 14.6.1 without crashes.

Also includes https://github.com/cirruslabs/macos-image-templates/pull/175/commits/7b0ac6c55915a25bce4be7f6e6677281235ce6fa as a follow-up to https://github.com/cirruslabs/macos-image-templates/pull/174.