### PR TITLE
Revert "Sonoma 14.6.1 (#170)"

### DIFF
--- a/templates/vanilla-sonoma.pkr.hcl
+++ b/templates/vanilla-sonoma.pkr.hcl
@@ -8,7 +8,7 @@ packer {
 }
 
 source "tart-cli" "tart" {
-  from_ipsw    = "https://updates.cdn-apple.com/2024SummerFCS/fullrestores/062-52859/932E0A8F-6644-4759-82DA-F8FA8DEA806A/UniversalMac_14.6.1_23G93_Restore.ipsw"
+  from_ipsw    = "https://updates.cdn-apple.com/2024SummerFCS/fullrestores/052-69922/F5DA2B64-25EB-4370-9E89-FA5689859796/UniversalMac_14.6_23G80_Restore.ipsw"
   vm_name      = "sonoma-vanilla"
   cpu_count    = 4
   memory_gb    = 8


### PR DESCRIPTION
This reverts commit 489255bec44e6906d063824bbeb2df85e6e66e23.

There've been reports that iOS simulator tests started hanging around the time of the update. Plus there are reports on the internet that 14.6.1 was breaking things.

Let's try to revert the 14.6 -> 14.6.1 update to see if that's really the case. All the regular trouble shooting didn't surface any other potential problems/regressions.