### PR TITLE
Start building Sequoia images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,6 +71,8 @@ task:
   matrix:
     - env:
         MACOS_VERSION: sonoma
+    - env:
+        MACOS_VERSION: sequoia
   only_if: $CIRRUS_CRON == "monthly"
   <<: *defaults
   pull_vanilla_script:
@@ -91,14 +93,14 @@ task:
   env:
     matrix:
       - MACOS_VERSION: sonoma
-        XCODE_VERSION: 15.4
+        XCODE_VERSION: 16
         LATEST: true
+      - MACOS_VERSION: sonoma
+        XCODE_VERSION: 15.4
       - MACOS_VERSION: sonoma
         XCODE_VERSION: 15.3
       - MACOS_VERSION: sonoma
         XCODE_VERSION: 15.2
-      - MACOS_VERSION: sonoma
-        XCODE_VERSION: 16
   <<: *defaults
   pull_base_script:
     - tart pull ghcr.io/cirruslabs/macos-$MACOS_VERSION-base:latest
@@ -121,7 +123,9 @@ task:
   env:
     matrix:
       - MACOS_VERSION: sonoma
-        XCODE_VERSIONS: 16,15.2,15.3,15.4
+        XCODE_VERSIONS: 15.2,15.3,15.4,16
+      - MACOS_VERSION: sequoia
+        XCODE_VERSIONS: 16-1-beta-2,15.4,16
   only_if: $CIRRUS_CRON == "weekly" # Every Sunday at 14 UTC
   <<: *defaults
   pull_base_script:


### PR DESCRIPTION
Only base the runner images. We are not planning to build per Xcode images to reduce amount of variants to support.

Related to #183