### PR TITLE
Send Slack alerts on build failures

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,3 +1,4 @@
+load("cirrus", "env", "http")
 load("github.com/cirrus-modules/graphql", "rerun_task_if_issue_in_logs")
 
 def on_task_failed(ctx):
@@ -5,3 +6,20 @@ def on_task_failed(ctx):
         print("Task is already an automatic re-run! Won't even try to re-run it...")
         return
     rerun_task_if_issue_in_logs(ctx.payload.data.task.id, "The network connection was lost")
+
+def on_build_failed(ctx):
+  resp = http.post("https://slack.com/api/chat.postMessage", headers={
+    "Content-Type": "application/json",
+    "Authorization": "Bearer " + env.get("SLACK_TOKEN"),
+  }, json_body={
+    "channel": "#image-updates",
+    "text": "Build <https://cirrus-ci.com/build/{build_id}|{build_id} (\"{change_message_title}\")> failed on branch \"{branch_name}\" in repository \"{repository_name}\".".format(build_id=ctx.payload.data.build.id, change_message_title=ctx.payload.data.build.changeMessageTitle, branch_name=ctx.payload.data.build.branch, repository_name=ctx.payload.data.repository.name),
+  })
+
+  if resp.status_code != 200:
+    fail("failed to post message to Slack: got unexpected HTTP {}".format(resp.status_code))
+
+  resp_json = resp.json()
+
+  if resp_json["ok"] != True:
+    fail("got error when posting message to Slack: {}".format(resp_json["error"]))


### PR DESCRIPTION
`SLACK_TOKEN` needs to be added to the repository's settings, though.