### PR TITLE
Update Android dependencies

### DIFF
--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -37,7 +37,7 @@ variable "disk_free_mb" {
 
 variable "android_sdk_tools_version" {
   type    = string
-  default = "11076708" # https://developer.android.com/studio/#command-tools
+  default = "11076708" # https://developer.android.com/studio#command-line-tools-only
 }
 
 source "tart-cli" "tart" {

--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -112,7 +112,7 @@ build {
       "rm android-sdk-tools.zip",
       "mv $ANDROID_HOME/cmdline-tools/cmdline-tools $ANDROID_HOME/cmdline-tools/latest",
       "yes | sdkmanager --licenses",
-      "yes | sdkmanager 'platform-tools' 'platforms;android-33' 'build-tools;34.0.0' 'ndk;25.2.9519653'"
+      "yes | sdkmanager 'platform-tools' 'platforms;android-35' 'build-tools;35.0.0' 'ndk;27.2.12479018'"
     ]
   }
 


### PR DESCRIPTION
## Context
* Due to the recent Android 15 (API 35) release, new versions of build tools are available. I updated the following dependencies
    * `platforms;android-35`
    * `build-tools;35.0.0`
    * `ndk;27.2.12479018`
* Fix link to Android command line tools 