### PR TITLE
Update vanilla-sequoia.pkr.hcl

### DIFF
--- a/templates/vanilla-sequoia.pkr.hcl
+++ b/templates/vanilla-sequoia.pkr.hcl
@@ -52,7 +52,7 @@ source "tart-cli" "tart" {
     # Are you sure you don't want to use Location Services?
     "<wait10s><tab><spacebar>",
     # Select Your Time Zone
-    "<wait10s><tab>UTC<enter><leftShiftOn><tab><leftShiftOff><spacebar>",
+    "<wait10s><tab><tab>UTC<enter><leftShiftOn><tab><tab><leftShiftOff><spacebar>",
     # Analytics
     "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar>",
     # Screen Time


### PR DESCRIPTION
It looks like the tab sequence for the Time Zone screen changed in one of the releases after 15.0.

I've tested this key sequence manually and via a packer build and it works with macOS 15.1.1.