### PR TITLE
Include Xcode 15.1 in Somoma runner

### DIFF
--- a/.ci/cirrus.runner.yml
+++ b/.ci/cirrus.runner.yml
@@ -4,8 +4,8 @@ task:
   env:
     matrix:
       - MACOS_VERSION: sonoma
-        XCODE_VERSIONS: "16,15.4,15.3,15.2,15.1,\"15.0.1\""
-        DISK_SIZE: 340
+        XCODE_VERSIONS: "16.1,16,15.4,15.3,15.2,15.1,\"15.0.1\""
+        DISK_SIZE: 375
       - MACOS_VERSION: sequoia
         XCODE_VERSIONS: "16.1,\"16.2-beta-3\",16,15.4"
         DISK_SIZE: 320

--- a/.ci/cirrus.xcode.yml
+++ b/.ci/cirrus.xcode.yml
@@ -13,8 +13,10 @@ task:
       - MACOS_VERSION: sequoia
         XCODE_VERSION: 15.4
       - MACOS_VERSION: sonoma
-        XCODE_VERSION: 16
+        XCODE_VERSION: 16.1
         LATEST: true
+      - MACOS_VERSION: sonoma
+        XCODE_VERSION: 16
       - MACOS_VERSION: sonoma
         XCODE_VERSION: 15.4
       - MACOS_VERSION: sonoma

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Some of the images are regularly getting rebuild in order to update the pre-inst
 monthly on the first Saturday of the month:
 
 * `ghcr.io/cirruslabs/macos-{sequoia,sonoma}-base`
-* `ghcr.io/cirruslabs/macos-runner:sonoma` which is a superset of `ghcr.io/cirruslabs/macos-sonoma-xcode:{latest,16,15.4,15.3,15.2,15.1,15.0.1}`
+* `ghcr.io/cirruslabs/macos-runner:sonoma` which is a superset of `ghcr.io/cirruslabs/macos-sonoma-xcode:{latest,16.1,16,15.4,15.3,15.2,15.1,15.0.1}`
 * `ghcr.io/cirruslabs/macos-runner:sequoia` which is a superset of `ghcr.io/cirruslabs/macos-sequoia-xcode:{latest,16.1,16.2-beta-3,16,15.4}`
 
 Note that `ghcr.io/cirruslabs/macos-runner:{sequoia,sonoma}` are updated every Sunday and these images are [optimised for startup](https://cirrus-runners.app/blog/2024/04/11/optimizing-startup-time-of-cirrus-runners/)


### PR DESCRIPTION
We unintentionally pushed Xcode 16.1 variant for `sonoma-xcode` image. We plan to only include new versions of Xcode with Sequoia images.

Instead for removing the 16.1 artifact. Let's include it in the runner image for consistency.