### PR TITLE
Compatibility with GitHub Actions Runner Images for /usr/local/bin

### DIFF
--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -240,6 +240,17 @@ build {
     ]
   }
 
+  # Compatibility with GitHub Actions Runner Images, where
+  # /usr/local/bin belongs to the default user. Also see [2].
+  #
+  # [1]: https://github.com/actions/runner-images/blob/6bbddd20d76d61606bea5a0133c950cc44c370d3/images/macos/scripts/build/configure-machine.sh#L96
+  # [2]: https://github.com/actions/runner-images/discussions/7607
+  provisioner "shell" {
+    inline = [
+      "sudo chown admin /usr/local/bin"
+    ]
+  }
+
   # Wait for the "update_dyld_sim_shared_cache" process[1][2] to finish
   # to avoid wasting CPU cycles after boot
   #


### PR DESCRIPTION
It's unclear why they do this, but could be related to https://github.com/actions/runner-images/discussions/7607.