### PR TITLE
Only pass a single item to "softwareupdate --install" each time

### DIFF
--- a/templates/vanilla-sequoia.pkr.hcl
+++ b/templates/vanilla-sequoia.pkr.hcl
@@ -130,7 +130,7 @@ build {
     inline = [
       # Install command-line tools
       "touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress",
-      "softwareupdate --list | sed -n 's/.*Label: \\(Command Line Tools for Xcode-.*\\)/\\1/p' | tr '\\n' '\\0' | xargs -0 softwareupdate --install",
+      "softwareupdate --list | sed -n 's/.*Label: \\(Command Line Tools for Xcode-.*\\)/\\1/p' | xargs -I {} softwareupdate --install '{}'",
       "rm /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress",
     ]
   }


### PR DESCRIPTION
This fixes the following error when building vanilla images:

```
Not enough free disk space: a total of 16.37 GB is required.
```