### PR TITLE
Ignore errors for "install available update" Ansible task

### DIFF
--- a/ansible/roles/system-updater/tasks/softwareupdate.yml
+++ b/ansible/roles/system-updater/tasks/softwareupdate.yml
@@ -24,8 +24,10 @@
   # > ssh: connect to host [...] port 22: Connection refused.
   ignore_unreachable: yes
   # Ignore SIGTERM/SIGKILL sent "softwareupdate" process
-  # when the system reboots due to --restart
-  failed_when: update_result.rc not in [0, 9, -9, 15, -15]
+  # when the system reboots due to --restart and any other errors,
+  # since we'll check whether the update was installed in main.yml
+  # anyway.
+  ignore_errors: yes
   become: yes
   loop: "{{ software_updates }}"
   when: "not item.label.startswith('macOS') or item.version.split('.')[0] == ansible_facts['distribution_version'].split('.')[0]"

--- a/ansible/roles/system-updater/tasks/softwareupdate.yml
+++ b/ansible/roles/system-updater/tasks/softwareupdate.yml
@@ -40,6 +40,4 @@
     # the commands below on a non-restarted system.
     delay: 60
     timeout: 1800
-  when:
-    - update_result is defined
-    - not update_result.skipped
+  when: update_result is defined and not update_result.skipped | default(false)


### PR DESCRIPTION
To work [around this error](https://cirrus-ci.com/task/6065544899592192?logs=build#L263) for Monterey:

```
    tart-cli.tart: TASK [system-updater : install available update] *******************************
    tart-cli.tart: task path: /private/tmp/cirrus-build/ansible/roles/system-updater/tasks/softwareupdate.yml:16
    tart-cli.tart: <192.168.64.2> ESTABLISH PARAMIKO SSH CONNECTION FOR USER: admin on PORT 22 TO 192.168.64.2
    tart-cli.tart: <192.168.64.2> EXEC /bin/sh -c 'echo ~admin && sleep 0'
    tart-cli.tart: <192.168.64.2> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/admin/.ansible/tmp `"&& mkdir "` echo /Users/admin/.ansible/tmp/ansible-tmp-1739442350.0018618-28520-105150308283942 `" && echo ansible-tmp-1739442350.0018618-28520-105150308283942="` echo /Users/admin/.ansible/tmp/ansible-tmp-1739442350.0018618-28520-105150308283942 `" ) && sleep 0'
    tart-cli.tart: Using module file /opt/homebrew/Cellar/ansible/11.2.0/libexec/lib/python3.13/site-packages/ansible/modules/command.py
    tart-cli.tart: <192.168.64.2> PUT /Users/administrator/.ansible/tmp/ansible-local-28514u1wb20a3/tmp18_vs1jw TO /Users/admin/.ansible/tmp/ansible-tmp-1739442350.0018618-28520-105150308283942/AnsiballZ_command.py
    tart-cli.tart: <192.168.64.2> EXEC /bin/sh -c 'chmod u+x /Users/admin/.ansible/tmp/ansible-tmp-1739442350.0018618-28520-105150308283942/ /Users/admin/.ansible/tmp/ansible-tmp-1739442350.0018618-28520-105150308283942/AnsiballZ_command.py && sleep 0'
    tart-cli.tart: <192.168.64.2> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-kfuglxlwdgobqmsmudjqulfiozhrdwnj ; /usr/bin/python3 /Users/admin/.ansible/tmp/ansible-tmp-1739442350.0018618-28520-105150308283942/AnsiballZ_command.py'"'"' && sleep 0'
    tart-cli.tart: fatal: [default]: FAILED! => {
    tart-cli.tart:     "msg": "Failed to open session: SSH session not active"
    tart-cli.tart: }
```

Ignoring all errors should be safe since we double-check whether all required updates were installed anyways: https://github.com/cirruslabs/macos-image-templates/blob/cdc53f0a12b54c48286eea95c1cd0b6b027c5dcf/ansible/roles/system-updater/tasks/main.yml#L33-L37