### PR TITLE
Use "-productVersion" instead of "--productVersion" to support Monterey

### DIFF
--- a/templates/resolve-macos-number.pkr.hcl
+++ b/templates/resolve-macos-number.pkr.hcl
@@ -34,7 +34,9 @@ build {
 
   provisioner "shell" {
     inline = [
-      "sw_vers --productVersion > /tmp/sw-vers-product-version.txt",
+      # Use "-productVersion" instead of "--productVersion"
+      # to support old-style syntax used on macOS Monterey
+      "sw_vers -productVersion > /tmp/sw-vers-product-version.txt",
     ]
   }
 

--- a/templates/vanilla-monterey.pkr.hcl
+++ b/templates/vanilla-monterey.pkr.hcl
@@ -85,7 +85,7 @@ source "tart-cli" "tart" {
   create_grace_time = "30s"
 
   // Keep the recovery partition, otherwise it's not possible to "softwareupdate"
-  recovery_partition = "relocate"
+  recovery_partition = "keep"
 }
 
 build {

--- a/templates/vanilla-sequoia.pkr.hcl
+++ b/templates/vanilla-sequoia.pkr.hcl
@@ -89,7 +89,7 @@ source "tart-cli" "tart" {
   create_grace_time = "30s"
 
   // Keep the recovery partition, otherwise it's not possible to "softwareupdate"
-  recovery_partition = "relocate"
+  recovery_partition = "keep"
 }
 
 build {

--- a/templates/vanilla-sonoma.pkr.hcl
+++ b/templates/vanilla-sonoma.pkr.hcl
@@ -84,7 +84,7 @@ source "tart-cli" "tart" {
   create_grace_time = "30s"
 
   // Keep the recovery partition, otherwise it's not possible to "softwareupdate"
-  recovery_partition = "relocate"
+  recovery_partition = "keep"
 }
 
 build {

--- a/templates/vanilla-ventura.pkr.hcl
+++ b/templates/vanilla-ventura.pkr.hcl
@@ -92,7 +92,7 @@ source "tart-cli" "tart" {
   create_grace_time = "30s"
 
   // Keep the recovery partition, otherwise it's not possible to "softwareupdate"
-  recovery_partition = "relocate"
+  recovery_partition = "keep"
 }
 
 build {


### PR DESCRIPTION
Should fix https://cirrus-ci.com/task/5028591282421760?logs=resolve_macos_number#L18.

Also no need to relocate anything as we're starting from scratch (IPSW).