### PR TITLE
Adapt disable-sip.pkr.hcl for new "csrutil" version in macOS Sequoia

### DIFF
--- a/.ci/cirrus.vanilla.yml
+++ b/.ci/cirrus.vanilla.yml
@@ -1,12 +1,14 @@
 env:
   RESOLVE_VM_NAME: "resolve-macos-number-task-id-${CIRRUS_TASK_ID}"
   RESOLVE_FILE: "${RESOLVE_VM_NAME}.txt"
+  DISABLE_SIP_TEMPLATE: disable-sip.pkr.hcl
 
 task:
   name: "Update Vanilla Image ($MACOS_VERSION)"
   env:
     matrix:
       - MACOS_VERSION: sequoia
+        DISABLE_SIP_TEMPLATE: disable-sip-with-username.pkr.hcl
       - MACOS_VERSION: sonoma
       - MACOS_VERSION: ventura
       - MACOS_VERSION: monterey
@@ -16,7 +18,7 @@ task:
     - packer init templates/vanilla-$MACOS_VERSION.pkr.hcl
     - packer build templates/vanilla-$MACOS_VERSION.pkr.hcl
   disable_sip_script:
-    - packer build -var vm_name=$MACOS_VERSION-vanilla templates/disable-sip.pkr.hcl
+    - packer build -var vm_name=$MACOS_VERSION-vanilla "templates/${DISABLE_SIP_TEMPLATE}"
   resolve_macos_number_script:
     - packer build -var vm_base_name=$MACOS_VERSION-vanilla -var vm_name=$RESOLVE_VM_NAME -var resolve_file=$RESOLVE_FILE templates/resolve-macos-number.pkr.hcl
     - echo "MACOS_NUMBER=$(cat $RESOLVE_FILE)" >> $CIRRUS_ENV

--- a/templates/disable-sip-with-username.pkr.hcl
+++ b/templates/disable-sip-with-username.pkr.hcl
@@ -1,0 +1,39 @@
+packer {
+  required_plugins {
+    tart = {
+      version = ">= 1.12.0"
+      source  = "github.com/cirruslabs/tart"
+    }
+  }
+}
+
+variable "vm_name" {
+  type = string
+}
+
+source "tart-cli" "tart" {
+  vm_name      = "${var.vm_name}"
+  recovery     = true
+  cpu_count    = 4
+  memory_gb    = 8
+  disk_size_gb = 50
+  communicator = "none"
+  boot_command = [
+    # Skip over "Macintosh" and select "Options"
+    # to boot into macOS Recovery
+    "<wait60s><right><right><enter>",
+    # Open Terminal
+    "<wait10s><leftAltOn>T<leftAltOff>",
+    # Disable SIP
+    "<wait10s>csrutil disable<enter>",
+    "<wait10s>y<enter>",
+    "<wait10s>admin<enter>",
+    "<wait10s>admin<enter>",
+    # Shutdown
+    "<wait10s>halt<enter>"
+  ]
+}
+
+build {
+  sources = ["source.tart-cli.tart"]
+}


### PR DESCRIPTION
`csrutil` on latest macOS Sequoia requires a username in addition to a password.