### PR TITLE
Split Tart Guest Agent invocations into daemon and agent variants

### DIFF
--- a/data/tart-guest-daemon.plist
+++ b/data/tart-guest-daemon.plist
@@ -3,12 +3,12 @@
 <plist version="1.0">
     <dict>
         <key>Label</key>
-        <string>org.cirruslabs.tart-guest-agent</string>
+        <string>org.cirruslabs.tart-guest-daemon</string>
         <key>Program</key>
         <string>/opt/homebrew/bin/tart-guest-agent</string>
         <key>ProgramArguments</key>
         <array>
-            <string>--run-vdagent</string>
+            <string>--resize-disk</string>
         </array>
         <key>EnvironmentVariables</key>
         <dict>

--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -152,17 +152,28 @@ build {
 
   // Guest agent for Tart VMs
   provisioner "file" {
+    source      = "data/tart-guest-daemon.plist"
+    destination = "~/tart-guest-daemon.plist"
+  }
+  provisioner "file" {
     source      = "data/tart-guest-agent.plist"
     destination = "~/tart-guest-agent.plist"
   }
   provisioner "shell" {
     inline = [
+      # Install Tart Guest Agent
       "source ~/.zprofile",
       "brew install cirruslabs/cli/tart-guest-agent",
-      "sudo mv ~/tart-guest-agent.plist /Library/LaunchDaemons/org.cirruslabs.tart-guest-agent.plist",
-      "sudo chown root:wheel /Library/LaunchDaemons/org.cirruslabs.tart-guest-agent.plist",
-      "sudo chmod 0644 /Library/LaunchDaemons/org.cirruslabs.tart-guest-agent.plist",
+
+      # Install daemon variant of the Tart Guest Agent
+      "sudo mv ~/tart-guest-daemon.plist /Library/LaunchDaemons/org.cirruslabs.tart-guest-daemon.plist",
+      "sudo chown root:wheel /Library/LaunchDaemons/org.cirruslabs.tart-guest-daemon.plist",
+      "sudo chmod 0644 /Library/LaunchDaemons/org.cirruslabs.tart-guest-daemon.plist",
+
+      # Install agent variant of the Tart Guest Agent
+      "sudo mv ~/tart-guest-agent.plist /Library/LaunchAgents/org.cirruslabs.tart-guest-agent.plist",
+      "sudo chown root:wheel /Library/LaunchAgents/org.cirruslabs.tart-guest-agent.plist",
+      "sudo chmod 0644 /Library/LaunchAgents/org.cirruslabs.tart-guest-agent.plist",
     ]
   }
 }
-


### PR DESCRIPTION
And run our own SPICE vdagent implementation to support clipboard sharing between the host and the guest.