### PR TITLE
Use separate log file for tart-guest-daemon

### DIFF
--- a/data/tart-guest-daemon.plist
+++ b/data/tart-guest-daemon.plist
@@ -21,8 +21,8 @@
         <key>KeepAlive</key>
         <true/>
         <key>StandardOutPath</key>
-        <string>/tmp/tart-guest-agent.log</string>
+        <string>/tmp/tart-guest-daemon.log</string>
         <key>StandardErrorPath</key>
-        <string>/tmp/tart-guest-agent.log</string>
+        <string>/tmp/tart-guest-daemon.log</string>
     </dict>
 </plist>


### PR DESCRIPTION
Otherwise `tart-guest-agent` fails to start due to permission errors, see https://github.com/cirruslabs/tart/issues/14#issuecomment-2872317058.