### PR TITLE
xcode.pkr.hcl: increase default disk size from 100 to 120 GB

### DIFF
--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -33,7 +33,7 @@ variable "tag" {
 
 variable "disk_size" {
   type = number
-  default = 100
+  default = 120
 }
 
 variable "disk_free_mb" {


### PR DESCRIPTION
Otherwise we get this when building `sequoia 16` variant of Xcode image:

<img width="928" alt="Screenshot 2025-05-13 at 11 16 26" src="https://github.com/user-attachments/assets/4cf21903-08f5-4865-ba65-da2dab7d5f25" />
