### PR TITLE
Tart Guest Agent: use component groups

### DIFF
--- a/data/tart-guest-agent.plist
+++ b/data/tart-guest-agent.plist
@@ -7,7 +7,7 @@
         <key>ProgramArguments</key>
         <array>
             <string>/opt/homebrew/bin/tart-guest-agent</string>
-            <string>--run-vdagent</string>
+            <string>--run-agent</string>
         </array>
         <key>EnvironmentVariables</key>
         <dict>

--- a/data/tart-guest-daemon.plist
+++ b/data/tart-guest-daemon.plist
@@ -7,7 +7,7 @@
         <key>ProgramArguments</key>
         <array>
             <string>/opt/homebrew/bin/tart-guest-agent</string>
-            <string>--resize-disk</string>
+            <string>--run-daemon</string>
         </array>
         <key>EnvironmentVariables</key>
         <dict>


### PR DESCRIPTION
So that we automatically run new Tart Guest Agent features appropriate for a given execution context.