### PR TITLE
tart-guest-agent: specify TERM and set working directory to HOME

### DIFF
--- a/data/tart-guest-agent.plist
+++ b/data/tart-guest-agent.plist
@@ -13,9 +13,11 @@
         <dict>
             <key>PATH</key>
             <string>/bin:/usr/bin:/usr/sbin:/usr/local/bin:/opt/homebrew/bin</string>
+            <key>TERM</key>
+            <string>xterm-256color</string>
         </dict>
         <key>WorkingDirectory</key>
-        <string>/var/empty</string>
+        <string>/Users/admin</string>
         <key>RunAtLoad</key>
         <true/>
         <key>KeepAlive</key>


### PR DESCRIPTION
Otherwise `htop` fails to start with `Error opening terminal: unknown` and running `ls` results in an empty output.

Ideally, merge this after https://github.com/cirruslabs/tart-guest-agent/pull/13 is merged to pick-up its fixes too.