### PR TITLE
Increase timeouts before "Select Your Country or Region"

### DIFF
--- a/templates/vanilla-tahoe.pkr.hcl
+++ b/templates/vanilla-tahoe.pkr.hcl
@@ -32,7 +32,7 @@ source "tart-cli" "tart" {
     # [1]: should be named "English (US)", but oh well 🤷
     "<wait30s>italiano<esc>english<enter>",
     # Select Your Country or Region
-    "<wait30s>united states<leftShiftOn><tab><leftShiftOff><spacebar>",
+    "<wait60s>united states<leftShiftOn><tab><leftShiftOff><spacebar>",
     # Transfer Your Data to This Mac
     "<wait10s><tab><tab><tab><spacebar><tab><tab><spacebar>",
     # Written and Spoken Languages
@@ -70,7 +70,7 @@ source "tart-cli" "tart" {
     # Update Mac Automatically
     "<wait10s><tab><tab><spacebar>",
     # Welcome to Mac
-    "<wait10s><spacebar>",
+    "<wait30s><spacebar>",
     # Disable Voice Over
     "<leftAltOn><f5><leftAltOff>",
     # Enable Keyboard navigation


### PR DESCRIPTION
...and "Welcome to Mac" screens.

Found these to be causing issues with automated installation when Tart window is minimized.