### PR TITLE
All simulators for the last 3 versions of Xcode

### DIFF
--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -168,6 +168,18 @@ build {
   }
 
   dynamic "provisioner" {
+    for_each = length(var.xcode_version) > 2 ? [2] : []
+    labels = ["shell"]
+    content {
+      inline = [
+        "source ~/.zprofile",
+        "sudo xcodes select '${var.xcode_version[2]}'",
+        "xcodebuild -downloadAllPlatforms",
+      ]
+    }
+  }
+
+  dynamic "provisioner" {
     for_each = length(var.xcode_version) > 1 ? [1] : []
     labels = ["shell"]
     content {


### PR DESCRIPTION
To align with https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#xcode-support-policy-update