### PR TITLE
Use Terminal to open System settings on Tahoe

### DIFF
--- a/templates/vanilla-tahoe.pkr.hcl
+++ b/templates/vanilla-tahoe.pkr.hcl
@@ -81,9 +81,9 @@ source "tart-cli" "tart" {
     # This is so that we can navigate the System Settings app using the keyboard
     "<wait10s><leftAltOn><spacebar><leftAltOff>Terminal<wait10s><enter>",
     "<wait10s><wait10s>defaults write NSGlobalDomain AppleKeyboardUIMode -int 3<enter>",
-    "<wait10s><leftAltOn>q<leftAltOff>",
     # Now that the installation is done, open "System Settings"
-    "<wait10s><leftAltOn><spacebar><leftAltOff>System Settings<wait10s><enter>",
+    # On Tahoe opening System Settings through Spotlight is not very reliable, sometimes opens System information
+    "<wait10s>open '/System/Applications/System Settings.app'<enter>",
     # Navigate to "Sharing"
     "<wait10s><leftCtrlOn><f2><leftCtrlOff><right><right><right><down>Sharing<enter>",
     # Navigate to "Screen Sharing" and enable it
@@ -93,12 +93,11 @@ source "tart-cli" "tart" {
     # Quit System Settings
     "<wait10s><leftAltOn>q<leftAltOff>",
     # Disable Gatekeeper (1/2)
-    "<wait10s><leftAltOn><spacebar><leftAltOff>Terminal<enter>",
     "<wait10s>sudo spctl --global-disable<enter>",
     "<wait10s>admin<enter>",
-    "<wait10s><leftAltOn>q<leftAltOff>",
     # Disable Gatekeeper (2/2)
-    "<wait10s><leftAltOn><spacebar><leftAltOff>System Settings<enter>",
+    # On Tahoe opening System Settings through Spotlight is not very reliable, sometimes opens System information
+    "<wait10s>open '/System/Applications/System Settings.app'<enter>",
     "<wait10s><leftCtrlOn><f2><leftCtrlOff><right><right><right><down>Privacy & Security<enter>",
     "<wait10s><leftShiftOn><tab><tab><tab><tab><tab><leftShiftOff>",
     "<wait10s><down><wait1s><down><wait1s><enter>",


### PR DESCRIPTION
Hi,

this PR should actually fix #275, I think that using Terminal to reliably open System Settings should actually be the way to go. I switch to this approach once I discovered this issue, seems to work just fine.

I am currently not entirely sure about reusing the terminal windows, saves some time, but single purpose terminal might be cleaner.

What do you think?