### PR TITLE
Remove asdf from base image provisioning

### DIFF
--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -105,8 +105,6 @@ build {
       "brew install libyaml", # https://github.com/rbenv/ruby-build/discussions/2118
       "brew install rbenv",
       "echo 'if which rbenv > /dev/null; then eval \"$(rbenv init -)\"; fi' >> ~/.zprofile",
-      "brew install asdf",
-      "echo 'export PATH=\"$${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH\"' >> ~/.zprofile",
       "brew install mise",
       "source ~/.zprofile",
       "rbenv install 2.7.8", // latest 2.x.x before EOL


### PR DESCRIPTION
## Summary
- remove the asdf installation and PATH export from the base image provisioning steps

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68da63ad720c83299268b786be539e34