### PR TITLE
Restart VM while building Xcode variant

### DIFF
--- a/templates/xcode.pkr.hcl
+++ b/templates/xcode.pkr.hcl
@@ -355,7 +355,7 @@ build {
   provisioner "shell" {
     inline = [
       "source ~/.zprofile",
-      "xcrun simctl runtime dyld_shared_cache update --all",
+      "xcrun simctl runtime dyld_shared_cache update --all || sleep 180",
       "xcrun simctl list -v",
     ]
   }
@@ -372,7 +372,7 @@ build {
   provisioner "shell" {
     inline = [
       "source ~/.zprofile",
-      "xcrun simctl runtime dyld_shared_cache update --all",
+      "xcrun simctl runtime dyld_shared_cache update --all || sleep 180",
       "xcrun simctl list -v"
     ]
     pause_before = "60s"


### PR DESCRIPTION
In an attempt to make https://github.com/actions/runner-images/issues/12948 less flaky. Xcode Release Notes at some point mentioend a first boot for another issue so let's make the VM boot twoce and do caching population just to be extra cautios.