### PR TITLE
Remove FileVault interaction from Packer boot command for macOS 26.1 compatibility

### DIFF
--- a/templates/vanilla-tahoe.pkr.hcl
+++ b/templates/vanilla-tahoe.pkr.hcl
@@ -65,10 +65,6 @@ source "tart-cli" "tart" {
     "<wait10s><tab><tab><spacebar>",
     # Siri
     "<wait10s><tab><spacebar><leftShiftOn><tab><leftShiftOff><spacebar>",
-    # You Mac is Ready for FileVault
-    "<wait10s><leftShiftOn><tab><tab><leftShiftOff><spacebar>",
-    # Mac Data Will Not Be Securely Encrypted
-    "<wait10s><tab><spacebar>",
     # Choose Your Look
     "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar>",
     # Update Mac Automatically


### PR DESCRIPTION
The FileVault prompt has been removed or skipped during macOS 26.1 setup, so this update deletes the corresponding part from the Packer boot automation to avoid errors.