### PR TITLE
Fix Gatekeeper disable step in boot command

### DIFF
--- a/templates/vanilla-tahoe.pkr.hcl
+++ b/templates/vanilla-tahoe.pkr.hcl
@@ -95,7 +95,7 @@ source "tart-cli" "tart" {
     # On Tahoe opening System Settings through Spotlight is not very reliable, sometimes opens System information
     "<wait10s>open '/System/Applications/System Settings.app'<enter>",
     "<wait10s><leftCtrlOn><f2><leftCtrlOff><right><right><right><down>Privacy & Security<enter>",
-    "<wait10s><leftShiftOn><tab><tab><tab><tab><tab><leftShiftOff>",
+    "<wait10s><leftShiftOn><tab><tab><tab><tab><tab><tab><leftShiftOff>",
     "<wait10s><down><wait1s><down><wait1s><enter>",
     "<wait10s>admin<enter>",
     "<wait10s><leftShiftOn><tab><leftShiftOff><wait1s><spacebar>",


### PR DESCRIPTION
Added the missing "tab" command in the "Disable GateKeeper (2/2)" section. Without this command, Gatekeeper was not fully disabled, causing the provisioner check to fail when verifying that Gatekeeper is disabled.