### PR TITLE
Revert "Remove explicit FileVault step from Packer boot command for m…

### DIFF
--- a/templates/vanilla-tahoe.pkr.hcl
+++ b/templates/vanilla-tahoe.pkr.hcl
@@ -65,6 +65,10 @@ source "tart-cli" "tart" {
     "<wait10s><tab><tab><spacebar>",
     # Siri
     "<wait10s><tab><spacebar><leftShiftOn><tab><leftShiftOff><spacebar>",
+    # You Mac is Ready for FileVault
+    "<wait10s><leftShiftOn><tab><tab><leftShiftOff><spacebar>",
+    # Mac Data Will Not Be Securely Encrypted
+    "<wait10s><tab><spacebar>",
     # Choose Your Look
     "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar>",
     # Update Mac Automatically


### PR DESCRIPTION
…acOS 26.1 compatibility (#305)"

This reverts commit e681fe0983a392c5071dcd754fe7c0ae48a6e182.