### PR TITLE
Updated Tahoe template to use macOS 26.3 restore image.

### DIFF
--- a/templates/vanilla-tahoe.pkr.hcl
+++ b/templates/vanilla-tahoe.pkr.hcl
@@ -12,7 +12,7 @@ packer {
 }
 
 source "tart-cli" "tart" {
-  from_ipsw    = "https://updates.cdn-apple.com/2025FallFCS/fullrestores/093-37399/E144C918-CF99-4BBC-B1D0-3E739B9A3F2D/UniversalMac_26.2_25C56_Restore.ipsw"
+  from_ipsw    = "https://updates.cdn-apple.com/2026WinterFCS/fullrestores/047-60229/6D5DBEA5-75A0-4BEF-ACC9-5ACF9B8DF6B7/UniversalMac_26.3_25D125_Restore.ipsw"
   vm_name      = "tahoe-vanilla"
   cpu_count    = 4
   memory_gb    = 8


### PR DESCRIPTION
Fixes #321