### PR TITLE
Add Golden Gate vanilla template

### DIFF
--- a/.github/workflows/vanilla.yml
+++ b/.github/workflows/vanilla.yml
@@ -13,6 +13,7 @@ on:
         type: choice
         options:
           - all
+          - golden-gate
           - tahoe
           - sequoia
           - sonoma
@@ -46,6 +47,7 @@ jobs:
       max-parallel: 1
       matrix:
         macos_version:
+          - golden-gate
           - tahoe
           - sequoia
           - sonoma

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ GitHub Actions runners, [Cirrus Runners](https://cirrus-runners.app/) or [any ot
 
 The following image variants are currently available:
 
-* `macos-{tahoe,sequoia,sonoma}-vanilla` — a vanilla macOS installation with helpful tweaks such as auto-login, but no additional software preinstalled
+* `macos-{golden-gate,tahoe,sequoia,sonoma}-vanilla` — a vanilla macOS installation with helpful tweaks such as auto-login, but no additional software preinstalled
 * `macos-{tahoe,sequoia,sonoma}-base` — based on `macos-{tahoe,sequoia,sonoma}-vanilla` image, it comes with `brew` and [other useful software](https://github.com/cirruslabs/macos-image-templates/blob/main/templates/base.pkr.hcl) pre-installed, but without Xcode
 * `macos-{tahoe,sequoia,sonoma}-xcode:N` — based on `macos-{tahoe,sequoia,sonoma}-base` image and has `Xcode N` with [`Flutter`](https://flutter.dev/) pre-installed
 * `macos-runner:{tahoe,sequoia,sonoma}` — a variant of `xcode:N` with several versions of `Xcode` pre-installed and [`xcodes` tool](https://github.com/XcodesOrg/xcodes) to switch between them.

--- a/templates/vanilla-golden-gate.pkr.hcl
+++ b/templates/vanilla-golden-gate.pkr.hcl
@@ -1,0 +1,168 @@
+packer {
+  required_plugins {
+    tart = {
+      version = ">= 1.16.0"
+      source  = "github.com/cirruslabs/tart"
+    }
+    ansible = {
+      version = "~> 1"
+      source  = "github.com/hashicorp/ansible"
+    }
+  }
+}
+
+source "tart-cli" "tart" {
+  from_ipsw    = "https://updates.cdn-apple.com/2026SummerSeed/fullrestores/122-99636/BB03A927-E303-44C1-BB94-6197F130A163/UniversalMac_27.0_26A5353q_Restore.ipsw"
+  vm_name      = "golden-gate-vanilla"
+  cpu_count    = 4
+  memory_gb    = 8
+  disk_size_gb = 50
+  ssh_password = "admin"
+  ssh_username = "admin"
+  ssh_timeout  = "180s"
+  boot_command = [
+    # hello, hola, bonjour, etc.
+    "<wait60s><spacebar>",
+    # Language: most of the times we have a list of "English"[1], "English (UK)", etc. with
+    # "English" language already selected. If we type "english", it'll cause us to switch
+    # to the "English (UK)", which is not what we want. To solve this, we switch to some other
+    # language first, e.g. "Italiano" and then switch back to "English". We'll then jump to the
+    # first entry in a list of "english"-prefixed items, which will be "English".
+    #
+    # [1]: should be named "English (US)", but oh well.
+    "<wait30s>italiano<esc>english<enter>",
+    # Select Your Country or Region
+    "<wait60s><click 'Select Your Country or Region'><wait5s>united states<leftShiftOn><tab><leftShiftOff><spacebar>",
+    # Transfer Your Data to This Mac
+    "<wait10s><tab><tab><tab><spacebar><tab><tab><spacebar>",
+    # Written and Spoken Languages
+    "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar>",
+    # Accessibility
+    "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar>",
+    # Data & Privacy
+    "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar>",
+    # Create a Mac Account
+    "<wait10s><tab><tab><tab><tab><tab><tab>Managed via Tart<tab>admin<tab>admin<tab>admin<tab><tab><spacebar><tab><tab><spacebar>",
+    # Enable Voice Over
+    "<wait120s><leftAltOn><f5><leftAltOff>",
+    # Sign In with Your Apple ID
+    "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar><up><spacebar>",
+    # Are you sure you want to skip signing in with an Apple ID?
+    "<wait10s><tab><spacebar>",
+    # Terms and Conditions
+    "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar>",
+    # I have read and agree to the macOS Software License Agreement
+    "<wait10s><tab><spacebar>",
+    # Age Range -> Adult
+    "<wait10s><tab><tab><tab><spacebar>",
+    # Choose Your Look
+    "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar>",
+    # Enable Location Services
+    "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar>",
+    # Are you sure you don't want to use Location Services?
+    "<wait10s><tab><spacebar>",
+    # Select Your Time Zone
+    "<wait10s><tab><tab><tab>UTC<enter><leftShiftOn><tab><leftShiftOff><spacebar>",
+    # Analytics
+    "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar>",
+    # Screen Time
+    "<wait10s><tab><tab><spacebar>",
+    # Siri
+    "<wait10s><tab><spacebar><leftShiftOn><tab><leftShiftOff><spacebar>",
+    # You Mac is Ready for FileVault
+    "<wait10s><leftShiftOn><tab><tab><leftShiftOff><spacebar>",
+    # Mac Data Will Not Be Securely Encrypted
+    "<wait10s><tab><spacebar>",
+    # Update Mac Automatically
+    "<wait10s><tab><tab><spacebar>",
+    # Liquid Glass
+    "<wait10s><leftShiftOn><tab><leftShiftOff><spacebar>",
+    # Welcome to Mac
+    "<wait30s><spacebar>",
+    # Disable Voice Over
+    "<wait10s><leftAltOn><f5><leftAltOff>",
+    # Enable Keyboard navigation
+    # This is so that we can navigate the System Settings app using the keyboard
+    "<wait10s><leftAltOn><spacebar><leftAltOff>Terminal<wait10s><enter>",
+    "<wait10s><wait10s>defaults write NSGlobalDomain AppleKeyboardUIMode -int 3<enter>",
+    # Enable Remote Login directly; the Sharing pane navigation below still mirrors Tahoe.
+    "<wait10s>echo admin | sudo -S systemsetup -setremotelogin on<enter>",
+    "<wait10s>echo admin | sudo -S launchctl load -w /System/Library/LaunchDaemons/ssh.plist<enter>",
+    # Now that the installation is done, open "System Settings"
+    # On Tahoe opening System Settings through Spotlight is not very reliable, sometimes opens System information
+    "<wait10s>open '/System/Applications/System Settings.app'<enter>",
+    "<wait120s>",
+    # Navigate to "Sharing"
+    "<wait10s><leftCtrlOn><f2><leftCtrlOff><right><right><right><down>Sharing<enter>",
+    # Navigate to "Screen Sharing" and enable it
+    "<wait10s><tab><tab><tab><tab><tab><spacebar>",
+    # Type in the password to allow enabling Screen Sharing
+    "<wait10s>admin<enter>",
+    # Navigate to "Remote Login" and enable it
+    "<wait10s><tab><tab><tab><tab><tab><tab><tab><tab><tab><tab><tab><tab><spacebar>",
+    # Quit System Settings
+    "<wait10s><leftAltOn>q<leftAltOff>",
+    # Disable Gatekeeper (1/2)
+    "<wait10s>sudo spctl --global-disable<enter>",
+    "<wait10s>admin<enter>",
+    # Disable Gatekeeper (2/2)
+    # On Tahoe opening System Settings through Spotlight is not very reliable, sometimes opens System information
+    "<wait10s>open '/System/Applications/System Settings.app'<enter>",
+    "<wait10s><leftCtrlOn><f2><leftCtrlOff><right><right><right><down>Privacy & Security<enter>",
+    "<wait10s><leftShiftOn><tab><tab><tab><tab><tab><tab><leftShiftOff>",
+    "<wait10s><down><wait1s><down><wait1s><enter>",
+    "<wait10s>admin<enter>",
+    "<wait10s><leftShiftOn><tab><leftShiftOff><wait1s><spacebar>",
+    # Quit System Settings
+    "<wait10s><leftAltOn>q<leftAltOff>",
+  ]
+
+  // A (hopefully) temporary workaround for Virtualization.Framework's
+  // installation process not fully finishing in a timely manner
+  create_grace_time = "30s"
+
+  // Keep the recovery partition, otherwise it's not possible to "softwareupdate"
+  recovery_partition = "keep"
+}
+
+build {
+  sources = ["source.tart-cli.tart"]
+
+  provisioner "shell" {
+    inline = [
+      // Enable passwordless sudo
+      "echo admin | sudo -S sh -c \"mkdir -p /etc/sudoers.d/; echo 'admin ALL=(ALL) NOPASSWD: ALL' | EDITOR=tee visudo /etc/sudoers.d/admin-nopasswd\"",
+      // Enable auto-login
+      //
+      // See https://github.com/xfreebird/kcpassword for details.
+      "echo '00000000: 1ced 3f4a bcbc ba2c caca 4e82' | sudo xxd -r - /etc/kcpassword",
+      "sudo defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser admin",
+      // Disable screensaver at login screen
+      "sudo defaults write /Library/Preferences/com.apple.screensaver loginWindowIdleTime 0",
+      // Disable screensaver for admin user
+      "defaults -currentHost write com.apple.screensaver idleTime 0",
+      // Prevent the VM from sleeping
+      "sudo systemsetup -setsleep Off 2>/dev/null",
+      // Launch Safari to populate the defaults
+      "/Applications/Safari.app/Contents/MacOS/Safari &",
+      "SAFARI_PID=$!",
+      "disown",
+      "sleep 30",
+      "kill -9 $SAFARI_PID",
+      // Enable Safari's remote automation
+      "sudo safaridriver --enable",
+      // Disable screen lock
+      //
+      // Note that this only works if the user is logged-in,
+      // i.e. not on login screen.
+      "sysadminctl -screenLock off -password admin",
+    ]
+  }
+
+  provisioner "shell" {
+    inline = [
+      # Ensure that Gatekeeper is disabled
+      "spctl --status | grep -q 'assessments disabled'"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `vanilla-golden-gate.pkr.hcl` template for macOS 27 Golden Gate using the 27.0 26A5353q restore IPSW
- wire `golden-gate` into the vanilla workflow matrix / dispatch choices and README image list

## Changes from Tahoe
- uses the Golden Gate IPSW and `golden-gate-vanilla` VM name
- keeps the Tahoe setup/provisioning flow as the base
- moves `Choose Your Look` to immediately after `Age Range -> Adult`, matching Golden Gate setup order
- adds the new `Liquid Glass` setup screen after `Update Mac Automatically`
- enables Remote Login directly with `systemsetup -setremotelogin on` plus loading `ssh.plist`, because Golden Gate's Sharing UI flow no longer reliably opens SSH by itself; the Tahoe Sharing navigation is still retained for the rest of that setup

## Verification
- `packer fmt -check -diff templates/vanilla-golden-gate.pkr.hcl`
- `PACKER_PLUGIN_PATH=/private/tmp/packer-plugins packer validate templates/vanilla-golden-gate.pkr.hcl`
- `git diff --check`
- full local Packer build completed successfully and produced Tart image `golden-gate-vanilla`
