### PR TITLE
Pre-install pnpm alongside yarn in base image

### DIFF
--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -122,6 +122,9 @@ build {
       "source ~/.zprofile",
       "node --version",
       "npm install --global yarn pnpm",
+      "echo 'export PNPM_HOME=\"$HOME/Library/pnpm\"' >> ~/.zprofile",
+      "echo 'export PATH=\"$PNPM_HOME:$PATH\"' >> ~/.zprofile",
+      "source ~/.zprofile",
       "yarn --version",
       "pnpm --version",
     ]

--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -123,6 +123,8 @@ build {
       "node --version",
       "npm install --global yarn",
       "yarn --version",
+      "npm install --global pnpm",
+      "pnpm --version",
     ]
   }
   provisioner "shell" {

--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -121,9 +121,8 @@ build {
       "echo 'export PATH=\"/opt/homebrew/opt/node@24/bin:$PATH\"' >> ~/.zprofile",
       "source ~/.zprofile",
       "node --version",
-      "npm install --global yarn",
+      "npm install --global yarn pnpm",
       "yarn --version",
-      "npm install --global pnpm",
       "pnpm --version",
     ]
   }


### PR DESCRIPTION
## Summary
- Install `pnpm` globally alongside `yarn` in the Node.js provisioner in `templates/base.pkr.hcl` via a single `npm install --global yarn pnpm` command.
- Configure `PNPM_HOME` (`$HOME/Library/pnpm`) and add it to `PATH` in `~/.zprofile`, matching pnpm's default macOS setup.
- Verify with `pnpm --version` so the base image ships both common Node package managers.

## Test plan
- [ ] Confirm the Node provisioner still installs `node@24`, `yarn`, and now `pnpm`
- [ ] Confirm `PNPM_HOME` is set and on `PATH` after sourcing `~/.zprofile`
- [ ] After the next base image rebuild, verify `pnpm --version` works in the VM