### PR TITLE
Fix Homebrew 6 trust failure in monthly image builds

### DIFF
--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -64,7 +64,7 @@ build {
       "brew --version",
       "brew update",
       "brew install wget unzip zip ca-certificates cmake gcc git-lfs jq yq gh gitlab-runner",
-      "brew install buildkite/buildkite/buildkite-agent",
+      "brew install buildkite/buildkite/buildkite-agent@3",
       "brew install equinix-labs/otel-cli/otel-cli",
       "brew install curl || true", // doesn't work on Monterey
       "brew install --cask git-credential-manager",


### PR DESCRIPTION
## Summary

- install the canonical `buildkite/buildkite/buildkite-agent@3` formula in the base image
- preserve the existing Buildkite agent v3 selection while allowing Homebrew to grant formula-scoped trust

## Root cause

The July and August monthly image builds failed for Sonoma, Sequoia, and Tahoe after Homebrew 6 enabled third-party tap trust enforcement by default. The existing command requested the renamed `buildkite-agent` formula, which resolves to `buildkite-agent@3`; Homebrew then refused to load that canonical target from the untrusted tap.

Because every base-image matrix job failed, the dependent Xcode-image matrix was skipped entirely.

Failing runs:

- https://github.com/cirruslabs/macos-image-templates/actions/runs/28701191312
- https://github.com/cirruslabs/macos-image-templates/actions/runs/30694815737

## Impact

Using the canonical fully qualified formula lets Homebrew trust only that formula and should unblock the common base-image failure without changing the installed Buildkite agent major version.

## Validation

- `packer fmt -check templates/base.pkr.hcl`
- `packer init templates/base.pkr.hcl`
- `packer validate -var vm_name=template-validation-base templates/base.pkr.hcl`
- `git diff --check`

The full Tart image build remains delegated to pull request CI.
