### PR TITLE
Fix base image automation microphone permissions

### DIFF
--- a/scripts/update-tcc-database.sh
+++ b/scripts/update-tcc-database.sh
@@ -13,7 +13,10 @@ source ~/.zprofile
 set -euo pipefail
 
 update_tcc_database() {
-  sudo sqlite3 "$1" <<-'EOF'
+  local tart_guest_agent_path
+  tart_guest_agent_path="$(realpath /opt/homebrew/bin/tart-guest-agent)"
+
+  sudo sqlite3 "$1" <<-EOF
 	INSERT OR REPLACE
 	INTO access (
 	  service,
@@ -40,11 +43,13 @@ update_tcc_database() {
 	-- Direct Python invocation
 	('kTCCServiceAccessibility', 0, 'org.python.python', 2, 0, 1, NULL, 'UNUSED'),
 	('kTCCServiceScreenCapture', 0, 'org.python.python', 2, 0, 1, NULL, 'UNUSED'),
+	('kTCCServiceMicrophone', 0, 'org.python.python', 2, 0, 1, NULL, 'UNUSED'),
 	('kTCCServicePostEvent', 0, 'org.python.python', 2, 0, 1, NULL, 'UNUSED'),
 	-- Commands invoked through the Tart Guest Agent
-	('kTCCServiceAccessibility', 1, '/opt/homebrew/bin/tart-guest-agent', 2, 0, 1, NULL, 'UNUSED'),
-	('kTCCServiceScreenCapture', 1, '/opt/homebrew/bin/tart-guest-agent', 2, 0, 1, NULL, 'UNUSED'),
-	('kTCCServicePostEvent', 1, '/opt/homebrew/bin/tart-guest-agent', 2, 0, 1, NULL, 'UNUSED');
+	('kTCCServiceAccessibility', 1, '${tart_guest_agent_path}', 2, 0, 1, NULL, 'UNUSED'),
+	('kTCCServiceScreenCapture', 1, '${tart_guest_agent_path}', 2, 0, 1, NULL, 'UNUSED'),
+	('kTCCServiceMicrophone', 1, '${tart_guest_agent_path}', 2, 0, 1, NULL, 'UNUSED'),
+	('kTCCServicePostEvent', 1, '${tart_guest_agent_path}', 2, 0, 1, NULL, 'UNUSED');
 	EOF
 }
 


### PR DESCRIPTION
## Summary
- Grant microphone access to the Homebrew Python bundle and Tart Guest Agent in both system and user TCC databases.
- Resolve the Homebrew Tart Guest Agent symlink before recording all guest-agent TCC permissions so macOS matches the actual executable in the Cellar.

## Why
Homebrew exposes Tart Guest Agent through a symlink under `/opt/homebrew/bin`, but macOS evaluates the resolved executable path for path-based TCC clients. Existing guest-agent grants therefore target the wrong identity, and neither automation identity currently receives microphone access.

## Validation
- `bash -n scripts/update-tcc-database.sh`
- `git diff --check`
- Executed the provisioning script twice against isolated system and user SQLite databases; confirmed both microphone grants, all four guest-agent grants use the resolved executable, existing permissions remain intact, and missing executables fail before database writes.
- Independent review agent reported no findings.