### PR TITLE
Install Tart Guest Agent from OpenAI tap

### DIFF
--- a/templates/base.pkr.hcl
+++ b/templates/base.pkr.hcl
@@ -168,7 +168,7 @@ build {
     inline = [
       # Install Tart Guest Agent
       "source ~/.zprofile",
-      "brew install cirruslabs/cli/tart-guest-agent",
+      "brew install openai/tools/tart-guest-agent",
 
       # Install daemon variant of the Tart Guest Agent
       "sudo mv ~/tart-guest-daemon.plist /Library/LaunchDaemons/org.cirruslabs.tart-guest-daemon.plist",


### PR DESCRIPTION
Cirrus Labs tap provides version `0.10.0`, but the [latest version is `0.12.0`](https://github.com/openai/tart-guest-agent/releases/tag/v0.12.0).