### PR TITLE
Update Tahoe images to Xcode 27 beta 6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,11 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        macos_version:
-          - tahoe
-          - sequoia
+        # Xcode 27 requires macOS Tahoe 26.4 or later.
+        macos_version: >-
+          ${{ startsWith(github.event.release.tag_name || inputs.xcode_version, '27')
+              && fromJSON('["tahoe"]')
+              || fromJSON('["tahoe", "sequoia"]') }}
     env:
       MACOS_VERSION: ${{ matrix.macos_version }}
       XCODE_COMPONENTS: '"MetalToolchain"'
@@ -105,7 +107,7 @@ jobs:
             xcode_components: '"MetalToolchain"'
             disk_size: 380
           - macos_version: tahoe
-            xcode_versions: '"26.6","27-beta-4","26.5","27-beta","26.4.1","26.3","26.2","26.1.1","26.0.1"'
+            xcode_versions: '"26.6","27-beta-6","26.5","27-beta","26.4.1","26.3","26.2","26.1.1","26.0.1"'
             additional_ios_builds: "18.6"
             additional_tvos_builds: ""
             xcode_components: '"MetalToolchain"'

--- a/.github/workflows/template-validation.yml
+++ b/.github/workflows/template-validation.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           mkdir -p "$HOME/XcodesCache"
           touch "$HOME/XcodesCache/Xcode_26.6.xip"
+          touch "$HOME/XcodesCache/Xcode_27-beta-6.xip"
 
       - name: Validate templates
         run: |
@@ -99,6 +100,11 @@ jobs:
             -var macos_version=tahoe \
             -var 'xcode_version=["26.6"]' \
             -var expected_runtimes_file=data/expected.tahoe.runtimes.txt
+
+          validate templates/xcode.pkr.hcl \
+            -var macos_version=tahoe \
+            -var 'xcode_version=["27-beta-6"]' \
+            -var 'xcode_components=["MetalToolchain"]'
 
   build-vanilla:
     name: Build Vanilla Image (${{ matrix.macos_version }})
@@ -246,7 +252,7 @@ jobs:
       matrix:
         include:
           - macos_version: tahoe
-            xcode_versions: '"26.6","27-beta-2","26.5","27-beta","26.4.1","26.3","26.2","26.1.1","26.0.1"'
+            xcode_versions: '"26.6","27-beta-6","26.5","27-beta","26.4.1","26.3","26.2","26.1.1","26.0.1"'
             additional_ios_builds: "18.6"
             additional_tvos_builds: ""
             xcode_components: '"MetalToolchain"'
@@ -342,8 +348,8 @@ jobs:
 
             candidate=""
             case "$version" in
-              27-beta-2)
-                candidate="$HOME/XcodesCache/Xcode_27_beta_2.xip"
+              27-beta-6)
+                candidate="$HOME/XcodesCache/Xcode_27_beta_6.xip"
                 ;;
               27-beta)
                 candidate="$HOME/XcodesCache/Xcode_27_beta.xip"

--- a/data/expected.tahoe.runtimes.txt
+++ b/data/expected.tahoe.runtimes.txt
@@ -6,10 +6,10 @@ iOS 26.3 (26.3.1 - 23D8133) - com.apple.CoreSimulator.SimRuntime.iOS-26-3
 iOS 26.4 (26.4.1 - 23E254a) - com.apple.CoreSimulator.SimRuntime.iOS-26-4
 iOS 26.5 (26.5 - 23F77) - com.apple.CoreSimulator.SimRuntime.iOS-26-5
 iOS 27.0 (27.0 - 24A5355p) - com.apple.CoreSimulator.SimRuntime.iOS-27-0
-iOS 27.0 (27.0 - 24A5370g) - com.apple.CoreSimulator.SimRuntime.iOS-27-0
+iOS 27.0 (27.0 - 24A5423a) - com.apple.CoreSimulator.SimRuntime.iOS-27-0
 tvOS 26.5 (26.5 - 23L470) - com.apple.CoreSimulator.SimRuntime.tvOS-26-5
-tvOS 27.0 (27.0 - 24J5305f) - com.apple.CoreSimulator.SimRuntime.tvOS-27-0
+tvOS 27.0 (27.0 - 24J5356a) - com.apple.CoreSimulator.SimRuntime.tvOS-27-0
 watchOS 26.5 (26.5 - 23T570) - com.apple.CoreSimulator.SimRuntime.watchOS-26-5
-watchOS 27.0 (27.0 - 24R5305f) - com.apple.CoreSimulator.SimRuntime.watchOS-27-0
+watchOS 27.0 (27.0 - 24R5355a) - com.apple.CoreSimulator.SimRuntime.watchOS-27-0
 visionOS 26.5 (26.5 - 23O470) - com.apple.CoreSimulator.SimRuntime.xrOS-26-5
-visionOS 27.0 (27.0 - 24M5306g) - com.apple.CoreSimulator.SimRuntime.xrOS-27-0
+visionOS 27.0 (27.0 - 24M5357a) - com.apple.CoreSimulator.SimRuntime.xrOS-27-0


### PR DESCRIPTION
Update the Tahoe runner and validation to Xcode 27 beta 6, keeping Xcode 26.6 as the default. Single-version Xcode 27 releases target Tahoe only; older release targets are unchanged.

Uses the existing cached-XIP installation and Packer template. No Golden Gate release target or beta-tag changes.

Local validation: actionlint, workflow/cache/tag checks, and four Packer configurations passed. Full VM builds have not been run.
